### PR TITLE
python: update multiple fields at the same time

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -13,7 +13,7 @@ slog-term = "2"
 time = "0.1"
 
 [dependencies.pyo3]
-version = "0.2"
+version = "0.2.7"
 features = ["extension-module"]
 default-features = false
 

--- a/python/portus/__init__.py
+++ b/python/portus/__init__.py
@@ -1,4 +1,4 @@
-from .pyportus import _connect, DatapathInfo, PyDatapath, PyReport, _test
+from .pyportus import _connect, DatapathInfo, PyDatapath, PyReport
 from abc import ABCMeta, abstractmethod
 import signal
 import sys


### PR DESCRIPTION
(When I initially implemented the python wrapper around update_fields I was lazy and just had it do a single field at a time because parsing a list of tuples from the python ffi is kind of annoying)