### PR TITLE
portus api: deduplicate programs across flows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "portus"
-version = "0.2.3"
-authors = ["Akshay Narayan <akshayn@csail.mit.edu>", "Frank Cangialosi <frankc@csail.mit.edu", "Deepti Raghavan <deeptir@stanford.edu"]
+version = "0.3.0"
+authors = ["Akshay Narayan <akshayn@csail.mit.edu>", "Frank Cangialosi <frankc@csail.mit.edu>", "Deepti Raghavan <deeptir@cs.stanford.edu>"]
 description = "A Congestion Control Plane"
 homepage = "https://ccp-project.github.io"
 documentation = "https://docs.rs/portus/0.2.3/portus/"

--- a/integration_tests/libccp_integration/src/bin/test_ccp.rs
+++ b/integration_tests/libccp_integration/src/bin/test_ccp.rs
@@ -14,7 +14,7 @@ use libccp_integration_test::{TestBasicSerialize, TestTiming, TestUpdateFields, 
 use std::process::{Command, Stdio};
 use portus::ipc::{BackendBuilder, Blocking};
 use portus::ipc::unix::Socket;
-use std::{thread,time};
+use std::thread;
 use std::sync::mpsc;
 use std::env;
 
@@ -64,6 +64,8 @@ fn start_libccp(libccp_location: String) -> std::process::Child {
 // Runs a specific intergration test
 fn run_test(libccp_location: String, log: slog::Logger, test: Test) {
     let (tx, rx) = mpsc::channel();
+    // spawn libccp
+    let mut libccp_process = start_libccp(libccp_location);
     let ccp_handle: portus::CCPHandle = match test {
         Test::TestBasicSerialize => start_ccp::<TestBasicSerialize<Socket<Blocking>>>(log, tx, test),
         Test::TestTiming => start_ccp::<TestTiming<Socket<Blocking>>>(log, tx, test),
@@ -73,10 +75,8 @@ fn run_test(libccp_location: String, log: slog::Logger, test: Test) {
     };
 
     // sleep before spawning mock datapath, so sockets can be setup properly
-    thread::sleep(time::Duration::from_millis(500));
+    //thread::sleep(time::Duration::from_millis(500));
 
-    // spawn libccp
-    let mut libccp_process = start_libccp(libccp_location);
     // wait for program to finish
     let wait_for_done = thread::spawn(move ||{
         let msg = rx.recv().unwrap();

--- a/src/serialize/changeprog.rs
+++ b/src/serialize/changeprog.rs
@@ -1,0 +1,83 @@
+//! CCP sends this message to change the datapath program currently in use.
+
+use std::io::prelude::*;
+use {Result, Error};
+use super::{AsRawMsg, RawMsg, HDR_LENGTH, u32_to_u8s, u64_to_u8s};
+use lang::{Reg};
+
+
+pub(crate) const CHANGEPROG: u8 = 4;
+
+#[derive(Clone)]
+#[derive(Debug)]
+#[derive(PartialEq)]
+pub struct Msg {
+    pub sid: u32,
+    pub program_uid: u32,
+    pub num_fields: u32,
+    pub fields: Vec<(Reg, u64)>,
+}
+
+impl AsRawMsg for Msg {
+    fn get_hdr(&self) -> (u8, u32, u32) {
+        (
+            CHANGEPROG,
+            HDR_LENGTH + 4 + 4 + self.num_fields * 13, // Reg size = 5, u64 size = 8
+            self.sid
+        )
+    }
+
+    fn get_u32s<W: Write>(&self, w: &mut W) -> Result<()> {
+        let mut buf = [0u8; 4];
+        u32_to_u8s(&mut buf, self.program_uid);
+        w.write_all(&buf[..])?;
+        u32_to_u8s(&mut buf, self.num_fields);
+        w.write_all(&buf[..])?;
+        Ok(())
+    }
+
+    fn get_bytes<W: Write>(&self, w: &mut W) -> Result<()> {
+        let mut buf = [0u8; 8];
+        for f in &self.fields {
+            let reg = f.0.clone().into_iter().map(|e| e.map_err(Error::from)).collect::<Result<Vec<u8>>>()?;
+            w.write_all(&reg[..])?;
+            u64_to_u8s(&mut buf, f.1);
+            w.write_all(&buf[..])?;
+        }
+        Ok(())
+    }
+    
+    // at least for now, portus does not have to worry about deserializing this message
+    fn from_raw_msg(_msg: RawMsg) -> Result<Self> {
+        unimplemented!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lang::{Bin, Prog, Reg};
+
+    #[test]
+    fn serialize_changeprog_msg() {
+        let m = super::Msg{
+            sid: 1,
+            program_uid: 7,
+            num_fields: 1,
+            fields: vec![(Reg::Implicit(4, ::lang::Type::Num(None)), 42)],
+        };
+
+        let buf: Vec<u8> = ::serialize::serialize::<super::Msg>(&m.clone()).expect("serialize");
+        assert_eq!(
+            buf,
+            vec![
+                4, 0,                                           // CHANGEPROG
+                29, 0,                                          // length = 12
+                1, 0, 0, 0,                                     // sock_id = 1
+                7, 0, 0, 0,                                     // program_uid = 7
+                1, 0, 0, 0,                                     // num_fields = 1
+                2, 4, 0, 0, 0, 0x2a, 0, 0, 0, 0, 0, 0, 0,        // Reg::Implicit(4) <- 42
+            ],
+        );
+    }
+}
+

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -153,6 +153,7 @@ mod test_helper {
 pub mod create;
 pub mod measure;
 pub mod install;
+pub mod changeprog;
 pub mod update_field;
 mod testmsg;
 


### PR DESCRIPTION
This commit adds an init_programs function to the CCP API where users
must provide all datapath programs at the beginning, and whenever a flow
should use a particular program, they can use the new "set_program"
function.

I'll split up the commits later, sorry.