### PR TITLE
Makefile: Change the way clippy is detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build test-portus test-ipc libccp-integration lint algs
 travis: build test-portus libccp-integration bindings
 
 OS := $(shell uname)
-CLIPPY := $(shell cargo --list | grep -c clippy)
+CLIPPY := $(shell rustup component list --toolchain nightly | grep "clippy" | grep -c "installed")
 
 build:
 	cargo +nightly build --all


### PR DESCRIPTION
Workaround for https://github.com/rust-lang-nursery/rustup.rs/issues/1514:
`cargo --list` will list clippy even if it is not installed. Instead,
query rustup components directly to detect clippy installation.