### PR TITLE
WIP: multi-threaded ccp

### DIFF
--- a/src/algs.rs
+++ b/src/algs.rs
@@ -115,7 +115,7 @@ macro_rules! start {
         match $ipc {
             "unix" => {
                 use $crate::ipc::unix::Socket;
-                let b = Socket::<$blk>::new("in", "out")
+                let b = Socket::<$blk>::new(0, "in", "out")
                     .map(|sk| BackendBuilder { sock: sk })
                     .expect("ipc initialization");
                 $crate::run::<_, _>(b, $crate::Config { logger: $log }, $alg)

--- a/src/bin/ipc_latency.rs
+++ b/src/bin/ipc_latency.rs
@@ -270,7 +270,7 @@ macro_rules! unix_bench {
             // listen
             let c1 = thread::spawn(move || {
                 let mut receive_buf = [0u8; 1024];
-                let unix = portus::ipc::unix::Socket::<$mode>::new("in", "out")
+                let unix = portus::ipc::unix::Socket::<$mode>::new(1, "in", "out")
                     .map(|sk| {
                         Backend::new(
                             sk,
@@ -286,7 +286,8 @@ macro_rules! unix_bench {
 
             // echo-er
             let c2 = thread::spawn(move || {
-                let sk = portus::ipc::unix::Socket::<Blocking>::new("out", "in").expect("sk init");
+                let sk =
+                    portus::ipc::unix::Socket::<Blocking>::new(1, "out", "in").expect("sk init");
                 let mut buf = [0u8; 1024];
                 ready_tx.send(true).expect("sync");
                 for _ in 0..iter {

--- a/src/bin/ipc_latency.rs
+++ b/src/bin/ipc_latency.rs
@@ -14,9 +14,10 @@ use std::sync::{atomic, Arc};
 use time::Duration;
 
 #[derive(Debug)]
-struct TimeMsg(time::Timespec);
+pub struct TimeMsg(time::Timespec);
 
 use std::io::prelude::*;
+
 impl portus::serialize::AsRawMsg for TimeMsg {
     fn get_hdr(&self) -> (u8, u32, u32) {
         (0xff, portus::serialize::HDR_LENGTH + 8 + 4, 0)
@@ -38,16 +39,19 @@ impl portus::serialize::AsRawMsg for TimeMsg {
         Ok(())
     }
 
-    fn from_raw_msg(msg: portus::serialize::RawMsg) -> portus::Result<Self> {
-        let b = msg.get_bytes()?;
-        let sec = LittleEndian::read_i64(&b[0..8]);
-        let nsec = LittleEndian::read_i32(&b[8..12]);
-        Ok(TimeMsg(time::Timespec::new(sec, nsec)))
+    fn from_raw_msg(_msg: portus::serialize::RawMsg) -> portus::Result<Self> {
+        unimplemented!()
     }
+}
+pub fn deserialize_timemsg(msg: portus::serialize::other::Msg) -> portus::Result<TimeMsg> {
+    let b = msg.get_raw_bytes();
+    let sec = LittleEndian::read_i64(&b[0..8]);
+    let nsec = LittleEndian::read_i32(&b[8..12]);
+    Ok(TimeMsg(time::Timespec::new(sec, nsec)))
 }
 
 #[derive(Debug)]
-struct NlTimeMsg {
+pub struct NlTimeMsg {
     kern_rt: time::Timespec,
     kern_st: time::Timespec,
 }
@@ -74,20 +78,23 @@ impl portus::serialize::AsRawMsg for NlTimeMsg {
         Ok(())
     }
 
-    fn from_raw_msg(msg: portus::serialize::RawMsg) -> portus::Result<Self> {
-        let b = msg.get_bytes()?;
-        let up_sec = LittleEndian::read_i64(&b[0..8]);
-        let up_nsec = LittleEndian::read_i32(&b[8..12]);
-        let down_sec = LittleEndian::read_i64(&b[12..20]);
-        let down_nsec = LittleEndian::read_i32(&b[20..24]);
-        Ok(NlTimeMsg {
-            kern_rt: time::Timespec::new(up_sec, up_nsec),
-            kern_st: time::Timespec::new(down_sec, down_nsec),
-        })
+    fn from_raw_msg(_msg: portus::serialize::RawMsg) -> portus::Result<Self> {
+        unimplemented!()
     }
 }
+pub fn deserialize_nltimemsg(msg: portus::serialize::other::Msg) -> portus::Result<NlTimeMsg> {
+    let b = msg.get_raw_bytes();
+    let up_sec = LittleEndian::read_i64(&b[0..8]);
+    let up_nsec = LittleEndian::read_i32(&b[8..12]);
+    let down_sec = LittleEndian::read_i64(&b[12..20]);
+    let down_nsec = LittleEndian::read_i32(&b[20..24]);
+    Ok(NlTimeMsg {
+        kern_rt: time::Timespec::new(up_sec, up_nsec),
+        kern_st: time::Timespec::new(down_sec, down_nsec),
+    })
+}
 
-use portus::serialize::AsRawMsg;
+use portus::ipc::SingleBackend;
 use std::sync::mpsc;
 fn bench<T: Ipc>(b: BackendSender<T>, mut l: Backend<T>, iter: u32) -> Vec<Duration> {
     (0..iter)
@@ -96,7 +103,7 @@ fn bench<T: Ipc>(b: BackendSender<T>, mut l: Backend<T>, iter: u32) -> Vec<Durat
             let msg = portus::serialize::serialize(&TimeMsg(then)).expect("serialize");
             b.send_msg(&msg[..]).expect("send ts");
             if let portus::serialize::Msg::Other(raw) = l.next().expect("receive echo") {
-                let then = TimeMsg::from_raw_msg(raw).expect("get time from raw");
+                let then = deserialize_timemsg(raw).expect("get time from raw");
                 time::get_time() - then.0
             } else {
                 panic!("wrong type");
@@ -150,7 +157,7 @@ macro_rules! netlink_bench {
                         if let portus::serialize::Msg::Other(raw) = nl.next().expect("recv echo") {
                             let portus_rt = time::get_time();
                             let kern_recv_msg =
-                                NlTimeMsg::from_raw_msg(raw).expect("get time from raw");
+                                deserialize_nltimemsg(raw).expect("get time from raw");
                             return NlDuration(
                                 portus_rt - portus_send_time,
                                 kern_recv_msg.kern_rt - portus_send_time,
@@ -260,7 +267,7 @@ macro_rules! unix_bench {
             // listen
             let c1 = thread::spawn(move || {
                 let unix = portus::ipc::unix::Socket::<$mode>::new(1, "in", "out")
-                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
+                    .map(|sk| SingleBackend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("unix ipc initialization");
                 ready_rx.recv().expect("sync");
                 tx.send(bench(unix.sender(), unix, iter))

--- a/src/bin/ipc_latency.rs
+++ b/src/bin/ipc_latency.rs
@@ -134,11 +134,8 @@ macro_rules! netlink_bench {
 
             // listen
             let c1 = thread::spawn(move || {
-                let mut buf = [0u8; 1024];
                 let mut nl = portus::ipc::netlink::Socket::<$mode>::new()
-                    .map(|sk| {
-                        Backend::new(sk, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..])
-                    })
+                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("nl ipc initialization");
                 tx.send(vec![]).expect("ok to insmod");
                 nl.next().expect("receive echo");
@@ -229,15 +226,8 @@ macro_rules! kp_bench {
                 .expect("load failed");
 
             let c1 = thread::spawn(move || {
-                let mut receive_buf = [0u8; 1024];
                 let kp = portus::ipc::kp::Socket::<$mode>::new()
-                    .map(|sk| {
-                        Backend::new(
-                            sk,
-                            Arc::new(atomic::AtomicBool::new(true)),
-                            &mut receive_buf[..],
-                        )
-                    })
+                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("kp ipc initialization");
                 tx.send(bench(kp.sender(), kp, iter)).expect("report rtts");
             });
@@ -269,15 +259,8 @@ macro_rules! unix_bench {
 
             // listen
             let c1 = thread::spawn(move || {
-                let mut receive_buf = [0u8; 1024];
                 let unix = portus::ipc::unix::Socket::<$mode>::new(1, "in", "out")
-                    .map(|sk| {
-                        Backend::new(
-                            sk,
-                            Arc::new(atomic::AtomicBool::new(true)),
-                            &mut receive_buf[..],
-                        )
-                    })
+                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("unix ipc initialization");
                 ready_rx.recv().expect("sync");
                 tx.send(bench(unix.sender(), unix, iter))

--- a/src/bin/ipc_latency.rs
+++ b/src/bin/ipc_latency.rs
@@ -96,7 +96,7 @@ pub fn deserialize_nltimemsg(msg: portus::serialize::other::Msg) -> portus::Resu
 
 use portus::ipc::SingleBackend;
 use std::sync::mpsc;
-fn bench<T: Ipc>(b: BackendSender<T>, mut l: Backend<T>, iter: u32) -> Vec<Duration> {
+fn bench<T: Ipc>(b: BackendSender<T>, mut l: SingleBackend<T>, iter: u32) -> Vec<Duration> {
     (0..iter)
         .map(|_| {
             let then = time::get_time();
@@ -142,7 +142,7 @@ macro_rules! netlink_bench {
             // listen
             let c1 = thread::spawn(move || {
                 let mut nl = portus::ipc::netlink::Socket::<$mode>::new()
-                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
+                    .map(|sk| SingleBackend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("nl ipc initialization");
                 tx.send(vec![]).expect("ok to insmod");
                 nl.next().expect("receive echo");
@@ -234,7 +234,7 @@ macro_rules! kp_bench {
 
             let c1 = thread::spawn(move || {
                 let kp = portus::ipc::kp::Socket::<$mode>::new()
-                    .map(|sk| Backend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
+                    .map(|sk| SingleBackend::new(sk, Arc::new(atomic::AtomicBool::new(true))))
                     .expect("kp ipc initialization");
                 tx.send(bench(kp.sender(), kp, iter)).expect("report rtts");
             });

--- a/src/ipc/test.rs
+++ b/src/ipc/test.rs
@@ -49,7 +49,7 @@ fn test_unix() {
 
     let c2 = thread::spawn(move || {
         rx.recv().expect("chan rcv");
-        let sk2 = super::unix::Socket::<Blocking>::new("out", "in").expect("init socket");
+        let sk2 = super::unix::Socket::<Blocking>::new(1, "out", "in").expect("init socket");
         let mut buf = [0u8; 1024];
         let b2 = super::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
         let test_msg = TestMsg(String::from("hello, world"));
@@ -59,7 +59,7 @@ fn test_unix() {
             .expect("send message");
     });
 
-    let sk1 = super::unix::Socket::<Blocking>::new("in", "out").expect("init socket");
+    let sk1 = super::unix::Socket::<Blocking>::new(1, "in", "out").expect("init socket");
     let mut buf = [0u8; 1024];
     let mut b1 = super::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
     tx.send(true).expect("chan send");

--- a/src/ipc/test.rs
+++ b/src/ipc/test.rs
@@ -66,7 +66,7 @@ fn test_unix() {
         Msg::Other(r) => {
             assert_eq!(r.typ, 0xff);
             assert_eq!(r.len, serialize::HDR_LENGTH + "hello, world".len() as u32);
-            assert_eq!(r.get_bytes().unwrap(), "hello, world".as_bytes());
+            assert_eq!(r.get_raw_bytes(), "hello, world".as_bytes());
         }
         _ => unreachable!(),
     }
@@ -107,7 +107,7 @@ fn test_chan() {
         Msg::Other(r) => {
             assert_eq!(r.typ, 0xff);
             assert_eq!(r.len, serialize::HDR_LENGTH + "hello, world".len() as u32);
-            assert_eq!(r.get_bytes().unwrap(), "hello, world".as_bytes());
+            assert_eq!(r.get_raw_bytes(), "hello, world".as_bytes());
         }
         _ => unreachable!(),
     }

--- a/src/ipc/test.rs
+++ b/src/ipc/test.rs
@@ -50,8 +50,7 @@ fn test_unix() {
     let c2 = thread::spawn(move || {
         rx.recv().expect("chan rcv");
         let sk2 = super::unix::Socket::<Blocking>::new(1, "out", "in").expect("init socket");
-        let mut buf = [0u8; 1024];
-        let b2 = super::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+        let b2 = super::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)));
         let test_msg = TestMsg(String::from("hello, world"));
         let test_msg_buf = serialize::serialize(&test_msg).expect("serialize test msg");
         b2.sender()
@@ -60,8 +59,7 @@ fn test_unix() {
     });
 
     let sk1 = super::unix::Socket::<Blocking>::new(1, "in", "out").expect("init socket");
-    let mut buf = [0u8; 1024];
-    let mut b1 = super::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+    let mut b1 = super::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)));
     tx.send(true).expect("chan send");
     match b1.next().expect("receive message") {
         // Msg::Other(RawMsg)
@@ -93,8 +91,7 @@ fn test_chan() {
     let c2 = thread::spawn(move || {
         rx.recv().expect("chan rcv");
         let sk2 = super::chan::Socket::<Blocking>::new(s1, r2);
-        let mut buf = [0u8; 1024];
-        let b2 = super::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+        let b2 = super::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)));
         let test_msg = TestMsg(String::from("hello, world"));
         let test_msg_buf = serialize::serialize(&test_msg).expect("serialize test msg");
         b2.sender()
@@ -103,8 +100,7 @@ fn test_chan() {
     });
 
     let sk1 = super::chan::Socket::<Blocking>::new(s2, r1);
-    let mut buf = [0u8; 1024];
-    let mut b1 = super::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+    let mut b1 = super::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)));
     tx.send(true).expect("chan send");
     match b1.next().expect("receive message") {
         // Msg::Other(RawMsg)

--- a/src/ipc/unix.rs
+++ b/src/ipc/unix.rs
@@ -6,9 +6,11 @@ use super::Result;
 use std::marker::PhantomData;
 
 macro_rules! unix_addr {
-    // TODO for now assumes just a single CCP (id=0)
-    ($x:expr) => {
-        format!("/tmp/ccp/0/{}", $x)
+    ($id:expr) => {
+        format!("/tmp/ccp/{}", $id)
+    };
+    ($id:expr, $dir:expr) => {
+        format!("/tmp/ccp/{}/{}", $id, $dir)
     };
 }
 
@@ -16,17 +18,18 @@ pub struct Socket<T> {
     sk: UnixDatagram,
     dest: String,
     _phantom: PhantomData<T>,
+    _id: u8
 }
 
 impl<T> Socket<T> {
     // Only the CCP process is allowed to use id = 0.
     // For all other datapaths, they should use a known unique identifier
     // such as the port number.
-    fn __new(bind_to: &str, send_to: &str) -> Result<Self> {
-        let bind_to_addr = unix_addr!(bind_to.to_string());
-        let send_to_addr = unix_addr!(send_to.to_string());
+    fn __new(id: u8, bind_to: &str, send_to: &str) -> Result<Self> {
+        let bind_to_addr = unix_addr!(id, bind_to);
+        let send_to_addr = unix_addr!(id, send_to);
         // create dir if not already exists
-        match std::fs::create_dir_all("/tmp/ccp/0").err() {
+        match std::fs::create_dir_all(unix_addr!(id)).err() {
             Some(ref e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
             Some(e) => Err(e),
             None => Ok(()),
@@ -45,6 +48,7 @@ impl<T> Socket<T> {
             sk: sock,
             dest: send_to_addr,
             _phantom: PhantomData,
+            _id : id
         })
     }
 }
@@ -73,15 +77,15 @@ impl<T: 'static + Sync + Send> super::Ipc for Socket<T> {
 
 use super::Blocking;
 impl Socket<Blocking> {
-    pub fn new(bind_to: &str, send_to: &str) -> Result<Self> {
-        Socket::__new(bind_to, send_to)
+    pub fn new(id: u8, bind_to: &str, send_to: &str) -> Result<Self> {
+        Socket::__new(id, bind_to, send_to)
     }
 }
 
 use super::Nonblocking;
 impl Socket<Nonblocking> {
-    pub fn new(bind_to: &str, send_to: &str) -> Result<Self> {
-        let sk = Socket::__new(bind_to, send_to)?;
+    pub fn new(id: u8, bind_to: &str, send_to: &str) -> Result<Self> {
+        let sk = Socket::__new(id, bind_to, send_to)?;
         sk.sk.set_nonblocking(true).map_err(Error::from)?;
         Ok(sk)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,12 @@ impl<T: Ipc> DatapathTrait for Datapath<T> {
     }
 }
 
-fn send_and_install<I>(sock_id: u32, sender: &BackendSender<I>, bin: Bin, sc: &Scope) -> Result<()>
+fn send_and_install<I>(
+    sock_id: u32,
+    sender: &BackendBroadcaster<I>,
+    bin: Bin,
+    sc: &Scope,
+) -> Result<()>
 where
     I: Ipc,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,8 +485,7 @@ where
     I: Ipc,
     U: CongAlg<I>,
 {
-    let mut receive_buf = [0u8; 1024];
-    let mut b = backend_builder.build(continue_listening.clone(), &mut receive_buf[..]);
+    let mut b = backend_builder.build(continue_listening.clone());
     let mut flows = HashMap::<u32, U::Flow>::default();
     let backend = b.sender();
 

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -156,6 +156,7 @@ pub mod changeprog;
 pub mod create;
 pub mod install;
 pub mod measure;
+pub mod other;
 mod testmsg;
 pub mod update_field;
 
@@ -193,21 +194,21 @@ fn deserialize(buf: &[u8]) -> Result<RawMsg> {
 /// a Msg of the corresponding type. If the message type is unkown, returns a
 /// wrapper with direct access to the message bytes.
 #[derive(Debug, PartialEq)]
-pub enum Msg<'a> {
+pub enum Msg {
     Cr(create::Msg),
     Ms(measure::Msg),
     Ins(install::Msg),
-    Other(RawMsg<'a>),
+    Other(other::Msg),
 }
 
-impl<'a> Msg<'a> {
+impl Msg {
     fn from_raw_msg(m: RawMsg) -> Result<Msg> {
         match m.typ {
             create::CREATE => Ok(Msg::Cr(create::Msg::from_raw_msg(m)?)),
             measure::MEASURE => Ok(Msg::Ms(measure::Msg::from_raw_msg(m)?)),
             install::INSTALL => Ok(Msg::Ins(install::Msg::from_raw_msg(m)?)),
             update_field::UPDATE_FIELD => unimplemented!(),
-            _ => Ok(Msg::Other(m)),
+            _ => Ok(Msg::Other(other::Msg::from_raw_msg(m)?)),
         }
     }
 
@@ -288,13 +289,13 @@ mod tests {
     #[test]
     fn test_other_msg() {
         use super::testmsg;
-        use super::AsRawMsg;
+
         let m = testmsg::Msg(String::from("testing"));
         let buf: Vec<u8> = super::serialize::<testmsg::Msg>(&m.clone()).expect("serialize");
         let (msg, _) = Msg::from_buf(&buf[..]).expect("deserialize");
         match msg {
-            Msg::Other(raw) => {
-                let got = testmsg::Msg::from_raw_msg(raw).expect("get raw msg");
+            Msg::Other(o) => {
+                let got = testmsg::Msg::from_other_msg(o).expect("get raw msg");
                 assert_eq!(m, got);
             }
             _ => panic!("wrong type for message"),
@@ -304,7 +305,6 @@ mod tests {
     #[test]
     fn test_multi_msg() {
         use super::testmsg;
-        use super::AsRawMsg;
 
         let m1 = testmsg::Msg(String::from("foo"));
         let m2 = testmsg::Msg(String::from("bar"));
@@ -313,8 +313,8 @@ mod tests {
 
         let (msg, len1) = Msg::from_buf(&buf[..]).expect("deserialize");
         match msg {
-            Msg::Other(raw) => {
-                let got = testmsg::Msg::from_raw_msg(raw).expect("get raw msg");
+            Msg::Other(o) => {
+                let got = testmsg::Msg::from_other_msg(o).expect("get raw msg");
                 assert_eq!(m1, got);
             }
             _ => panic!("wrong type for message"),
@@ -322,8 +322,8 @@ mod tests {
 
         let (msg, len2) = Msg::from_buf(&buf[len1..]).expect("deserialize");
         match msg {
-            Msg::Other(raw) => {
-                let got = testmsg::Msg::from_raw_msg(raw).expect("get raw msg");
+            Msg::Other(o) => {
+                let got = testmsg::Msg::from_other_msg(o).expect("get raw msg");
                 assert_eq!(m2, got);
             }
             _ => panic!("wrong type for message"),

--- a/src/serialize/other.rs
+++ b/src/serialize/other.rs
@@ -1,0 +1,41 @@
+//! Message sent from datapath to CCP when a new flow starts.
+
+use super::{AsRawMsg, RawMsg, HDR_LENGTH};
+use crate::Result;
+use std::io::prelude::*;
+
+pub(crate) const OTHER: u8 = 255;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Msg {
+    pub typ: u8,
+    pub len: u32,
+    pub sid: u32,
+    bytes: Vec<u8>,
+}
+
+impl AsRawMsg for Msg {
+    fn get_hdr(&self) -> (u8, u32, u32) {
+        (OTHER, HDR_LENGTH + self.bytes.len() as u32, self.sid)
+    }
+
+    fn get_bytes<W: Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn from_raw_msg(msg: RawMsg) -> Result<Self> {
+        Ok(Msg {
+            typ: msg.typ,
+            len: msg.len,
+            sid: msg.sid,
+            bytes: msg.get_bytes().unwrap().to_vec(),
+        })
+    }
+}
+
+impl Msg {
+    pub fn get_raw_bytes(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+}

--- a/src/serialize/testmsg.rs
+++ b/src/serialize/testmsg.rs
@@ -23,3 +23,12 @@ impl AsRawMsg for Msg {
         Ok(Msg(st))
     }
 }
+#[cfg(test)]
+impl Msg {
+    pub fn from_other_msg(msg: super::other::Msg) -> Result<Self> {
+        let b = msg.get_raw_bytes();
+        let s = std::str::from_utf8(b)?;
+        let st = String::from(s);
+        Ok(Msg(st))
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,8 +9,7 @@ fn test_ser_over_ipc() {
     let sk = ipc::test::FakeIpc::new();
     let sk1 = sk.clone();
     let c1 = thread::spawn(move || {
-        let mut buf = [0u8; 1024];
-        let mut b1 = ipc::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+        let mut b1 = ipc::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)));
         tx.send(true).expect("ready chan send");
         let msg = b1.next().expect("receive message");
         assert_eq!(
@@ -27,8 +26,7 @@ fn test_ser_over_ipc() {
     let sk2 = sk.clone();
     let c2 = thread::spawn(move || {
         rx.recv().expect("ready chan rcv");
-        let mut buf = [0u8; 1024];
-        let b2 = ipc::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+        let b2 = ipc::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)));
 
         // serialize a message
         let m = serialize::measure::Msg {
@@ -55,13 +53,11 @@ fn bench_ser_over_ipc(b: &mut Bencher) {
     let (s1, r1) = crossbeam::channel::unbounded();
     let (s2, r2) = crossbeam::channel::unbounded();
 
-    let mut buf = [0u8; 1024];
     let sk1 = ipc::chan::Socket::<Blocking>::new(s1, r2);
-    let mut b1 = ipc::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)), &mut buf[..]);
+    let mut b1 = ipc::Backend::new(sk1, Arc::new(atomic::AtomicBool::new(true)));
 
-    let mut buf2 = [0u8; 1024];
     let sk2 = ipc::chan::Socket::<Blocking>::new(s2, r1);
-    let b2 = ipc::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)), &mut buf2[..]);
+    let b2 = ipc::Backend::new(sk2, Arc::new(atomic::AtomicBool::new(true)));
 
     let m = serialize::measure::Msg {
         sid: 42,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -76,5 +76,9 @@ impl IntegrationTest for TestBasicSerialize {
 fn basic() {
     let log = libccp_integration::logger();
     info!(log, "starting basic test");
-    libccp_integration::run_test::<TestBasicSerialize>(log, 1);
+    libccp_integration::run_test::<TestBasicSerialize>(log, 1, false);
+
+    let log2 = libccp_integration::logger();
+    info!(log2, "starting basic test (multi)");
+    libccp_integration::run_test::<TestBasicSerialize>(log2, 1, true);
 }

--- a/tests/libccp_integration/mod.rs
+++ b/tests/libccp_integration/mod.rs
@@ -80,7 +80,7 @@ impl<I: Ipc, T: IntegrationTest> Flow for TestBase<I, T> {
 }
 
 use portus::ipc::chan::Socket;
-use portus::ipc::{BackendBuilder, Blocking};
+use portus::ipc::{SingleBackendBuilder, Blocking};
 use std;
 use std::thread;
 
@@ -90,8 +90,8 @@ fn start_ccp<T: IntegrationTest + 'static + Send>(
     log: slog::Logger,
     tx: mpsc::Sender<Result<(), ()>>,
 ) -> portus::CCPHandle {
-    let b = BackendBuilder { sock: sk };
-    portus::spawn::<Socket<Blocking>, TestBaseConfig<T>>(
+    let b = SingleBackendBuilder { sock: sk };
+    portus::spawn::<Socket<Blocking>, TestBaseConfig<T>, SingleBackendBuilder<Socket<Blocking>>>(
         b,
         portus::Config {
             logger: Some(log.clone()),

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -69,5 +69,5 @@ impl IntegrationTest for TestPresetVars {
 fn preset() {
     let log = libccp_integration::logger();
     info!(log, "starting preset test");
-    libccp_integration::run_test::<TestPresetVars>(log, 1);
+    libccp_integration::run_test::<TestPresetVars>(log, 1, false);
 }

--- a/tests/timing.rs
+++ b/tests/timing.rs
@@ -83,5 +83,5 @@ impl IntegrationTest for TestTiming {
 fn timing() {
     let log = libccp_integration::logger();
     info!(log, "starting timing test");
-    libccp_integration::run_test::<TestTiming>(log, 1);
+    libccp_integration::run_test::<TestTiming>(log, 1, false);
 }

--- a/tests/twoflow.rs
+++ b/tests/twoflow.rs
@@ -88,5 +88,5 @@ impl IntegrationTest for TestTwoFlows {
 fn twoflow() {
     let log = libccp_integration::logger();
     info!(log, "starting twoflow test");
-    libccp_integration::run_test::<TestTwoFlows>(log, 2);
+    libccp_integration::run_test::<TestTwoFlows>(log, 2, false);
 }

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -88,5 +88,5 @@ impl IntegrationTest for TestUpdateFields {
 fn update() {
     let log = libccp_integration::logger();
     info!(log, "starting update test");
-    libccp_integration::run_test::<TestUpdateFields>(log, 1);
+    libccp_integration::run_test::<TestUpdateFields>(log, 1, false);
 }

--- a/tests/volatile.rs
+++ b/tests/volatile.rs
@@ -74,5 +74,5 @@ impl IntegrationTest for TestVolatileVars {
 fn volatile() {
     let log = libccp_integration::logger();
     info!(log, "starting volatile test");
-    libccp_integration::run_test::<TestVolatileVars>(log, 1);
+    libccp_integration::run_test::<TestVolatileVars>(log, 1, false);
 }


### PR DESCRIPTION
This is a WIP, not ready to be merged yet. 

This PR contains a few commits to enable an easier integration with mvfst.

The only change to the interface is an additional typeparameter to run allowing for different backendbuilders to be passed in. The traditional backend and backendbuilder were renamed to singlebackend and singlebackendbuilder. 

Once this new interface is in place, it's possible to implement multi-threaded ccp without changing the api or internal run_inner implementation by implementing a multibackend (and multibackendbuilder). 

