### PR TITLE
Support for running multiple algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bytes = "0.4.5"
 clap = "2.32"
 colored = "1.7"
 crossbeam = "0.7"
-fnv = "1"
 itertools = "0.8"
 libc = "0.2"
 libloading = "0.5"
@@ -42,6 +41,6 @@ version = "0.15"
 features = ["full", "visit", "fold", "extra-traits","parsing"]
 
 [dev-dependencies]
-failure = "0.1"
-libccp = "0.0.12"
+anyhow = "1"
+libccp = "1"
 minion = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portus"
-version = "0.5.5"
+version = "0.6.0"
 authors = ["Akshay Narayan <akshayn@csail.mit.edu>", "Frank Cangialosi <frankc@csail.mit.edu>", "Deepti Raghavan <deeptir@cs.stanford.edu>"]
 description = "A Congestion Control Plane"
 homepage = "https://ccp-project.github.io"
@@ -13,28 +13,29 @@ edition = "2018"
 [features]
 default = []
 lang-verbose-errors = ["nom/verbose-errors"]
+ccp_bin = ["structopt", "itertools", "quote", "regex", "toml", "proc-macro2", "libloading", "walkdir"]
 
 [dependencies]
-bytes = "0.4.5"
-clap = "2.32"
-colored = "1.7"
-crossbeam = "0.7"
-itertools = "0.8"
-libc = "0.2"
-libloading = "0.5"
-nix = "0.9.0"
-nom = "4"
-portus_export = "0.1"
-proc-macro2 = "0.4"
-quote = "0.6"
-regex = "1.1"
-slog = "2"
-slog-async = "2"
-slog-term = "2"
-structopt = "0.2"
-time = "0.1"
-toml = "0.4"
-walkdir = "2"
+bytes          =  "0.4.5"
+clap           =  "2.32"
+colored        =  "1.7"
+crossbeam      =  "0.7"
+libc           =  "0.2"
+nix            =  "0.9.0"
+nom            =  "4"
+portus_export  =  "0.1"
+slog           =  "2"
+slog-async     =  "2"
+slog-term      =  "2"
+time           =  "0.1"
+structopt    =  { version = "0.2", optional = true }
+itertools    =  { version = "0.8", optional = true }
+quote        =  { version = "0.6", optional = true }
+regex        =  { version = "1.1", optional = true }
+toml         =  { version = "0.4", optional = true }
+proc-macro2  =  { version = "0.4", optional = true }
+libloading   =  { version = "0.5", optional = true }
+walkdir      =  { version = "2", optional = true }
 
 [dependencies.syn]
 version = "0.15"
@@ -44,3 +45,11 @@ features = ["full", "visit", "fold", "extra-traits","parsing"]
 anyhow = "1"
 libccp = "1"
 minion = "0.1"
+
+[[bin]]
+name = "ccp"
+required-features = ["ccp_bin"]
+
+[[bin]]
+name = "cargo-compile-fast-path"
+required-features = ["ccp_bin"]

--- a/src/algs.rs
+++ b/src/algs.rs
@@ -118,7 +118,9 @@ macro_rules! start {
                 let b = Socket::<$blk>::new("in", "out")
                     .map(|sk| BackendBuilder { sock: sk })
                     .expect("ipc initialization");
-                $crate::run::<_, _>(b, $crate::Config { logger: $log }, $alg)
+                $crate::RunBuilder::new(b, $crate::Config { logger: $log })
+                    .default_alg($alg)
+                    .run()
             }
             #[cfg(all(target_os = "linux"))]
             "netlink" => {
@@ -126,7 +128,9 @@ macro_rules! start {
                 let b = Socket::<$blk>::new()
                     .map(|sk| BackendBuilder { sock: sk })
                     .expect("ipc initialization");
-                $crate::run::<_, _>(b, $crate::Config { logger: $log }, $alg)
+                $crate::RunBuilder::new(b, $crate::Config { logger: $log })
+                    .default_alg($alg)
+                    .run()
             }
             #[cfg(all(target_os = "linux"))]
             "char" => {
@@ -134,7 +138,9 @@ macro_rules! start {
                 let b = Socket::<$blk>::new()
                     .map(|sk| BackendBuilder { sock: sk })
                     .expect("ipc initialization");
-                $crate::run::<_, _>(b, $crate::Config { logger: $log }, $alg)
+                $crate::RunBuilder::new(b, $crate::Config { logger: $log })
+                    .default_alg($alg)
+                    .run()
             }
             _ => unreachable!(),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
-use std;
 use std::fmt;
+
+/// CCP custom `Result` type, using `Error` as the `Err` type.
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Debug)]
 /// CCP custom error type.

--- a/src/ipc/chan.rs
+++ b/src/ipc/chan.rs
@@ -1,5 +1,3 @@
-use std;
-
 use crossbeam::channel;
 
 use super::Error;

--- a/src/ipc/kp.rs
+++ b/src/ipc/kp.rs
@@ -1,7 +1,3 @@
-extern crate libc;
-extern crate nix;
-
-use std;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::marker::PhantomData;

--- a/src/ipc/netlink.rs
+++ b/src/ipc/netlink.rs
@@ -11,7 +11,7 @@ use nix::sys::socket;
 pub struct Socket<T>(c_int, PhantomData<T>);
 
 const NL_CFG_F_NONROOT_RECV: c_int = 1;
-const NL_CFG_F_NONROOT_SEND: c_int = (1 << 1);
+const NL_CFG_F_NONROOT_SEND: c_int = 1 << 1;
 const NLMSG_HDRSIZE: usize = 0x10;
 
 impl<T> Socket<T> {

--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -392,7 +392,7 @@ mod tests {
                     ),],
                 );
             }
-            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -16,7 +16,7 @@
 //! to prevent double-counting these values in the CCP algorithm logic.
 //!
 //! ### Example
-//! ```no-run
+//! ```text
 //! (def
 //!     (state_var 0)
 //!     (Report
@@ -36,7 +36,7 @@
 //! `(fallthrough)` is specified.
 //!
 //! ### Example
-//! ```no-run
+//! ```text
 //! (when true
 //!     (:= Report.minrtt (min Report.minrtt Flow.rtt_sample_us))
 //!     (fallthrough)

--- a/src/lang/prog.rs
+++ b/src/lang/prog.rs
@@ -222,7 +222,7 @@ mod tests {
                     ]
                 );
             }
-            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }
@@ -244,7 +244,7 @@ mod tests {
                     ),]
                 );
             }
-            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }
@@ -257,7 +257,7 @@ mod tests {
         match super::defs(CompleteByteSlice(foo)) {
             Ok((r, me)) => panic!("Should not have succeeded: rest {:?}, result {:?}", r, me),
             Err(nom::Err::Error(_)) => (),
-            Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }
@@ -283,7 +283,7 @@ mod tests {
                 );
             }
             Ok((_, Err(me))) => {
-                panic!(me);
+                panic!("{}", me);
             }
             Err(nom::Err::Error(_)) => (),
             Err(nom::Err::Failure(e)) => panic!("compilation error: {}", super::Error::from(e)),
@@ -328,9 +328,9 @@ mod tests {
                 );
             }
             Ok((_, Err(me))) => {
-                panic!(me);
+                panic!("{}", me);
             }
-            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }
@@ -398,7 +398,7 @@ mod tests {
                     ],
                 );
             }
-            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!(e),
+            Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => panic!("{:?}", e),
             Err(nom::Err::Incomplete(Needed::Unknown)) => panic!("incomplete"),
             Err(nom::Err::Incomplete(Needed::Size(s))) => panic!("need {} more bytes", s),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,6 @@ extern crate slog;
 
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::{atomic, Arc};
-use std::thread;
 
 pub mod ipc;
 pub mod lang;
@@ -84,13 +82,9 @@ mod errors;
 pub use crate::errors::*;
 pub use portus_export::register_ccp_alg;
 
+use crate::ipc::BackendSender;
 use crate::ipc::Ipc;
-use crate::ipc::{BackendBuilder, BackendSender};
 use crate::lang::{Bin, Reg, Scope};
-use crate::serialize::Msg;
-
-/// CCP custom `Result` type, using `Error` as the `Err` type.
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// A collection of methods to interact with the datapath.
 pub trait DatapathTrait {
@@ -219,13 +213,6 @@ where
     let buf = serialize::serialize(&msg)?;
     sender.send_msg(&buf[..])?;
     Ok(())
-}
-
-/// Configuration parameters for the portus runtime.
-/// Defines a `slog::Logger` to use for (optional) logging
-#[derive(Clone, Default)]
-pub struct Config {
-    pub logger: Option<slog::Logger>,
 }
 
 /// The set of information passed by the datapath to CCP
@@ -369,240 +356,8 @@ pub trait CongAlgBuilder<'a, 'b> {
         Self: Sized;
 }
 
-/// A handle to manage running instances of the CCP execution loop.
-#[derive(Debug)]
-pub struct CCPHandle {
-    pub continue_listening: Arc<atomic::AtomicBool>,
-    pub join_handle: thread::JoinHandle<Result<()>>,
-}
-
-impl CCPHandle {
-    /// Instruct the execution loop to exit.
-    pub fn kill(&self) {
-        self.continue_listening
-            .store(false, atomic::Ordering::SeqCst);
-    }
-
-    // TODO: join_handle.join() returns an Err instead of Ok, because
-    // some function panicked, this function should return an error
-    // with the same string from the panic.
-    /// Collect the error from the thread running the CCP execution loop
-    /// once it exits.
-    pub fn wait(self) -> Result<()> {
-        match self.join_handle.join() {
-            Ok(r) => r,
-            Err(_) => Err(Error(String::from("Call to run_inner panicked"))),
-        }
-    }
-}
-
-/// Main execution loop of CCP for the static pipeline use case.
-/// The `run` method blocks 'forever'; it only returns in two cases:
-/// 1. The IPC socket is closed.
-/// 2. An invalid message is received.
-///
-/// Callers must construct a `BackendBuilder` and a `Config`.
-/// Algorithm implementations should
-/// 1. Initializes an ipc backendbuilder (depending on the datapath).
-/// 2. Calls `run()`, or `spawn() `passing the `BackendBuilder b` and a `Config` with optional
-/// logger and command line argument structure.
-/// Run() or spawn() create arc<AtomicBool> objects,
-/// which are passed into run_inner to build the backend, so spawn() can create a CCPHandle that references this
-/// boolean to kill the thread.
-// TODO once feature(never_type) is stabilized, this should return Result<!>
-pub fn run<I, U>(backend_builder: BackendBuilder<I>, cfg: Config, alg: U) -> Result<()>
-where
-    I: Ipc,
-    U: CongAlg<I>,
-{
-    // call run_inner
-    run_inner(
-        Arc::new(atomic::AtomicBool::new(true)),
-        backend_builder,
-        cfg,
-        alg,
-    )
-}
-
-/// Same as [`run`] but takes pointer to a kill switch instead of creating it as in spawn.
-///
-/// safety: `handle_ptr` must be from
-/// [`Arc::into_raw()`](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.from_raw).
-pub unsafe fn run_with_handle<I, U>(
-    backend_builder: BackendBuilder<I>,
-    cfg: Config,
-    alg: U,
-    handle_ptr: *const atomic::AtomicBool,
-) -> Result<()>
-where
-    I: Ipc,
-    U: CongAlg<I>,
-{
-    if handle_ptr.is_null() {
-        return Err(Error(format!("handle is null")));
-    }
-
-    let handle = Arc::from_raw(handle_ptr);
-
-    // call run_inner
-    run_inner(handle, backend_builder, cfg, alg)
-}
-
-/// Spawn a thread which will perform the CCP execution loop. Returns
-/// a `CCPHandle`, which the caller can use to cause the execution loop
-/// to stop.
-/// The `run` method blocks 'forever'; it only returns in three cases:
-/// 1. The IPC socket is closed.
-/// 2. An invalid message is received.
-/// 3. The caller calls `CCPHandle::kill()`
-///
-/// See [`run`](./fn.run.html) for more information.
-pub fn spawn<I, U>(backend_builder: BackendBuilder<I>, cfg: Config, alg: U) -> CCPHandle
-where
-    I: Ipc,
-    U: CongAlg<I> + 'static + Send,
-{
-    let stop_signal = Arc::new(atomic::AtomicBool::new(true));
-    CCPHandle {
-        continue_listening: stop_signal.clone(),
-        join_handle: thread::spawn(move || run_inner(stop_signal, backend_builder, cfg, alg)),
-    }
-}
-
-// Main execution inner loop of ccp.
-// Blocks "forever", or until the iterator stops iterating.
-//
-// `run_inner()`:
-// 1. listens for messages from the datapath
-// 2. call the appropriate message in `U: impl CongAlg`
-// The function can return for two reasons: an error, or the iterator returned None.
-// The latter should only happen for spawn(), and not for run().
-// It returns any error, either from:
-// 1. the IPC channel failing
-// 2. Receiving an install control message (only the datapath should receive these).
-fn run_inner<I, U>(
-    continue_listening: Arc<atomic::AtomicBool>,
-    backend_builder: BackendBuilder<I>,
-    cfg: Config,
-    alg: U,
-) -> Result<()>
-where
-    I: Ipc,
-    U: CongAlg<I>,
-{
-    let mut receive_buf = [0u8; 1024];
-    let mut b = backend_builder.build(continue_listening.clone(), &mut receive_buf[..]);
-    let mut flows = HashMap::<u32, U::Flow>::default();
-    let backend = b.sender();
-
-    if let Some(log) = cfg.logger.as_ref() {
-        info!(log, "starting CCP";
-            "algorithm" => U::name(),
-            "ipc"       => I::name(),
-        );
-    }
-
-    let mut scope_map = Rc::new(HashMap::<String, Scope>::default());
-
-    let programs = alg.datapath_programs();
-    for (program_name, program) in programs.iter() {
-        match lang::compile(program.as_bytes(), &[]) {
-            Ok((bin, sc)) => {
-                match send_and_install(0, &backend, bin, &sc) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        return Err(Error(format!(
-                            "Failed to install datapath program \"{}\": {:?}",
-                            program_name, e
-                        )));
-                    }
-                }
-                Rc::get_mut(&mut scope_map)
-                    .unwrap()
-                    .insert(program_name.to_string(), sc.clone());
-            }
-            Err(e) => {
-                return Err(Error(format!(
-                    "Datapath program \"{}\" failed to compile: {:?}",
-                    program_name, e
-                )));
-            }
-        }
-    }
-
-    while let Some(msg) = b.next() {
-        match msg {
-            Msg::Cr(c) => {
-                if flows.remove(&c.sid).is_some() {
-                    if let Some(log) = cfg.logger.as_ref() {
-                        debug!(log, "re-creating already created flow"; "sid" => c.sid);
-                    }
-                }
-
-                if let Some(log) = cfg.logger.as_ref() {
-                    debug!(log, "creating new flow";
-                           "sid" => c.sid,
-                           "init_cwnd" => c.init_cwnd,
-                           "mss"  =>  c.mss,
-                           "src_ip"  =>  c.src_ip,
-                           "src_port"  =>  c.src_port,
-                           "dst_ip"  =>  c.dst_ip,
-                           "dst_port"  =>  c.dst_port,
-                    );
-                }
-
-                let f = alg.new_flow(
-                    Datapath {
-                        sock_id: c.sid,
-                        sender: backend.clone(),
-                        programs: scope_map.clone(),
-                    },
-                    DatapathInfo {
-                        sock_id: c.sid,
-                        init_cwnd: c.init_cwnd,
-                        mss: c.mss,
-                        src_ip: c.src_ip,
-                        src_port: c.src_port,
-                        dst_ip: c.dst_ip,
-                        dst_port: c.dst_port,
-                    },
-                );
-                flows.insert(c.sid, f);
-            }
-            Msg::Ms(m) => {
-                if flows.contains_key(&m.sid) {
-                    if m.num_fields == 0 {
-                        let mut alg = flows.remove(&m.sid).unwrap();
-                        alg.close();
-                    } else {
-                        let alg = flows.get_mut(&m.sid).unwrap();
-                        alg.on_report(
-                            m.sid,
-                            Report {
-                                program_uid: m.program_uid,
-                                fields: m.fields,
-                            },
-                        )
-                    }
-                } else if let Some(log) = cfg.logger.as_ref() {
-                    debug!(log, "measurement for unknown flow"; "sid" => m.sid);
-                }
-            }
-            Msg::Ins(_) => {
-                // The start() listener should never receive an install message, since it is on the CCP side.
-                unreachable!()
-            }
-            _ => continue,
-        }
-    }
-
-    // if the thread has been killed, return that as error
-    if !continue_listening.load(atomic::Ordering::SeqCst) {
-        Ok(())
-    } else {
-        Err(Error(String::from("The IPC channel has closed.")))
-    }
-}
+mod run;
+pub use run::*;
 
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@
 //! minimum RTT observed over 42 millisecond intervals.
 //!
 //! ```
-//! extern crate fnv;
-//! extern crate portus;
 //! use std::collections::HashMap;
 //! use portus::{CongAlg, Flow, Config, Datapath, DatapathInfo, DatapathTrait, Report};
 //! use portus::ipc::Ipc;
@@ -318,7 +316,6 @@ pub trait CongAlg<I: Ipc> {
     ///
     /// For example,
     /// ```
-    /// extern crate fnv;
     /// use std::collections::HashMap;
     /// let mut h = HashMap::new();
     /// h.insert("prog1", "...(program)...".to_string());
@@ -331,15 +328,9 @@ pub trait CongAlg<I: Ipc> {
     fn new_flow(&self, control: Datapath<I>, info: DatapathInfo) -> Self::Flow;
 }
 
-/// Structs implementing [`portus::CongAlg`](./trait.CongAlg.html) must also implement this trait
-/// (and must be annotated with [`portus_export::register_ccp_alg`]())
+/// Tell `portus` how to construct instances of your `impl` [`portus::CongAlg`].
 ///
-/// The expected use of this trait in a calling program is as follows:
-/// ```no-run
-/// let args = CongAlgBuilder::args();
-/// let matches = app.get_matches_from(std::env::args_os());
-/// let alg = CongAlgBuilder::with_arg_matches(matches);
-/// ```
+/// You should also annotate your struct with [`portus_export::register_ccp_alg`]()).
 pub trait CongAlgBuilder<'a, 'b> {
     /// This function should return a new
     /// [`clap::App`](https://docs.rs/clap/2.32.0/clap/struct.App.html) that describes the

--- a/src/run.rs
+++ b/src/run.rs
@@ -152,32 +152,30 @@ mod sealed {
         }
     }
 
-    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for AlgList<T, U>
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for AlgList<Option<T>, U>
     where
         U: Pick<'a, I> + 'a,
         <U as Pick<'a, I>>::Picked: 'a,
     {
         type Picked = Either<&'a T, <U as Pick<'a, I>>::Picked>;
         fn pick(&'a self, name: &str) -> Self::Picked {
-            if self.head_name == name {
-                Either::Left(&self.head)
-            } else {
-                Either::Right(self.tail.pick(name))
+            match self.head {
+                Some(ref head) if self.head_name == name => Either::Left(&head),
+                _ => Either::Right(self.tail.pick(name)),
             }
         }
     }
 
-    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for &'a AlgList<T, U>
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for &'a AlgList<Option<T>, U>
     where
         U: Pick<'a, I> + 'a,
         <U as Pick<'a, I>>::Picked: 'a,
     {
         type Picked = Either<&'a T, <U as Pick<'a, I>>::Picked>;
         fn pick(&'a self, name: &str) -> Self::Picked {
-            if self.head_name == name {
-                Either::Left(&self.head)
-            } else {
-                Either::Right(self.tail.pick(name))
+            match self.head {
+                Some(ref head) if self.head_name == name => Either::Left(&head),
+                _ => Either::Right(self.tail.pick(name)),
             }
         }
     }
@@ -204,7 +202,7 @@ mod sealed {
         }
     }
 
-    impl<H, T, I> CollectDps<I> for AlgList<H, T>
+    impl<H, T, I> CollectDps<I> for AlgList<Option<H>, T>
     where
         I: Ipc,
         H: CongAlg<I>,
@@ -212,14 +210,15 @@ mod sealed {
     {
         fn datapath_programs(&self) -> HashMap<&'static str, String> {
             self.head
-                .datapath_programs()
+                .iter()
+                .flat_map(|x| x.datapath_programs())
                 .into_iter()
                 .chain(self.tail.datapath_programs().into_iter())
                 .collect()
         }
     }
 
-    impl<'a, H, T, I> CollectDps<I> for &'a AlgList<H, T>
+    impl<'a, H, T, I> CollectDps<I> for &'a AlgList<Option<H>, T>
     where
         I: Ipc,
         H: CongAlg<I>,
@@ -227,7 +226,8 @@ mod sealed {
     {
         fn datapath_programs(&self) -> HashMap<&'static str, String> {
             self.head
-                .datapath_programs()
+                .iter()
+                .flat_map(|x| x.datapath_programs())
                 .into_iter()
                 .chain(self.tail.datapath_programs().into_iter())
                 .collect()
@@ -377,11 +377,14 @@ impl<I: Ipc, U, S> RunBuilder<I, U, S> {
     /// Set an additional congestion control algorithm.
     ///
     /// If the name duplicates one already given, the later one will win.
-    pub fn additional_alg<A: CongAlg<I>>(self, alg: A) -> RunBuilder<I, AlgList<A, U>, S> {
+    pub fn additional_alg<A: CongAlg<I>>(
+        self,
+        alg: impl Into<Option<A>>,
+    ) -> RunBuilder<I, AlgList<Option<A>, U>, S> {
         RunBuilder {
             alg: AlgList {
                 head_name: A::name().to_owned(),
-                head: alg,
+                head: alg.into(),
                 tail: self.alg,
             },
             backend_builder: self.backend_builder,

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,616 @@
+//! Utilities to start a CCP processing worker.
+
+use crate::ipc::BackendBuilder;
+use crate::ipc::Ipc;
+use crate::lang::Scope;
+use crate::serialize::Msg;
+use crate::{lang, send_and_install, CongAlg, Datapath, DatapathInfo, Error, Flow, Report, Result};
+use slog::{debug, info};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{atomic, Arc};
+use std::thread;
+
+/// Configuration parameters for the portus runtime.
+/// Defines a `slog::Logger` to use for (optional) logging
+#[derive(Clone, Default)]
+pub struct Config {
+    pub logger: Option<slog::Logger>,
+}
+
+/// A handle to manage running instances of the CCP execution loop.
+#[derive(Debug)]
+pub struct CCPHandle {
+    pub continue_listening: Arc<atomic::AtomicBool>,
+    pub join_handle: thread::JoinHandle<Result<()>>,
+}
+
+impl CCPHandle {
+    /// Instruct the execution loop to exit.
+    pub fn kill(&self) {
+        self.continue_listening
+            .store(false, atomic::Ordering::SeqCst);
+    }
+
+    // TODO: join_handle.join() returns an Err instead of Ok, because
+    // some function panicked, this function should return an error
+    // with the same string from the panic.
+    /// Collect the error from the thread running the CCP execution loop
+    /// once it exits.
+    pub fn wait(self) -> Result<()> {
+        match self.join_handle.join() {
+            Ok(r) => r,
+            Err(_) => Err(Error(String::from("Call to run_inner panicked"))),
+        }
+    }
+}
+
+mod sealed {
+    use crate::{ipc::Ipc, CongAlg, Datapath, DatapathInfo, Flow, Report};
+    use std::collections::HashMap;
+
+    pub struct AlgList<Head, Tail> {
+        pub head_name: String,
+        pub head: Head,
+        pub tail: Tail,
+    }
+
+    pub struct AlgListNil<H>(pub H);
+
+    pub enum Either<L, R> {
+        Left(L),
+        Right(R),
+    }
+
+    impl<L, R> Flow for Either<L, R>
+    where
+        L: Flow,
+        R: Flow,
+    {
+        fn on_report(&mut self, sock_id: u32, m: Report) {
+            use Either::*;
+            match self {
+                Left(l) => l.on_report(sock_id, m),
+                Right(r) => r.on_report(sock_id, m),
+            }
+        }
+
+        fn close(&mut self) {
+            use Either::*;
+            match self {
+                Left(l) => l.close(),
+                Right(r) => r.close(),
+            }
+        }
+    }
+
+    impl<L, R, I> CongAlg<I> for Either<L, R>
+    where
+        I: Ipc,
+        L: CongAlg<I>,
+        R: CongAlg<I>,
+    {
+        type Flow = Either<L::Flow, R::Flow>;
+
+        fn name() -> &'static str {
+            ""
+        }
+
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            use Either::*;
+            match self {
+                Left(l) => l.datapath_programs(),
+                Right(r) => r.datapath_programs(),
+            }
+        }
+
+        fn new_flow(&self, control: Datapath<I>, info: DatapathInfo) -> Self::Flow {
+            use Either::*;
+            match self {
+                Left(l) => Left(l.new_flow(control, info)),
+                Right(r) => Right(r.new_flow(control, info)),
+            }
+        }
+    }
+
+    impl<T, I> CongAlg<I> for &T
+    where
+        I: Ipc,
+        T: CongAlg<I>,
+    {
+        type Flow = T::Flow;
+
+        fn name() -> &'static str {
+            T::name()
+        }
+
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            T::datapath_programs(self)
+        }
+
+        fn new_flow(&self, control: Datapath<I>, info: DatapathInfo) -> Self::Flow {
+            T::new_flow(self, control, info)
+        }
+    }
+
+    pub trait Pick<'a, I: Ipc> {
+        type Picked: CongAlg<I> + 'a;
+        fn pick(&'a self, name: &str) -> Self::Picked;
+    }
+
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a> Pick<'a, I> for AlgListNil<T> {
+        type Picked = &'a T;
+        fn pick(&'a self, _: &str) -> Self::Picked {
+            &self.0
+        }
+    }
+
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a> Pick<'a, I> for &'a AlgListNil<T> {
+        type Picked = &'a T;
+        fn pick(&'a self, _: &str) -> Self::Picked {
+            &self.0
+        }
+    }
+
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for AlgList<T, U>
+    where
+        U: Pick<'a, I> + 'a,
+        <U as Pick<'a, I>>::Picked: 'a,
+    {
+        type Picked = Either<&'a T, <U as Pick<'a, I>>::Picked>;
+        fn pick(&'a self, name: &str) -> Self::Picked {
+            if self.head_name == name {
+                Either::Left(&self.head)
+            } else {
+                Either::Right(self.tail.pick(name))
+            }
+        }
+    }
+
+    impl<'a, I: Ipc, T: CongAlg<I> + 'a, U> Pick<'a, I> for &'a AlgList<T, U>
+    where
+        U: Pick<'a, I> + 'a,
+        <U as Pick<'a, I>>::Picked: 'a,
+    {
+        type Picked = Either<&'a T, <U as Pick<'a, I>>::Picked>;
+        fn pick(&'a self, name: &str) -> Self::Picked {
+            if self.head_name == name {
+                Either::Left(&self.head)
+            } else {
+                Either::Right(self.tail.pick(name))
+            }
+        }
+    }
+
+    pub trait CollectDps<I> {
+        fn datapath_programs(&self) -> HashMap<&'static str, String>;
+    }
+
+    impl<I: Ipc, T> CollectDps<I> for AlgListNil<T>
+    where
+        T: CongAlg<I>,
+    {
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            self.0.datapath_programs()
+        }
+    }
+
+    impl<'a, I: Ipc, T> CollectDps<I> for &'a AlgListNil<T>
+    where
+        T: CongAlg<I>,
+    {
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            self.0.datapath_programs()
+        }
+    }
+
+    impl<H, T, I> CollectDps<I> for AlgList<H, T>
+    where
+        I: Ipc,
+        H: CongAlg<I>,
+        T: CollectDps<I>,
+    {
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            self.head
+                .datapath_programs()
+                .into_iter()
+                .chain(self.tail.datapath_programs().into_iter())
+                .collect()
+        }
+    }
+
+    impl<'a, H, T, I> CollectDps<I> for &'a AlgList<H, T>
+    where
+        I: Ipc,
+        H: CongAlg<I>,
+        T: CollectDps<I>,
+    {
+        fn datapath_programs(&self) -> HashMap<&'static str, String> {
+            self.head
+                .datapath_programs()
+                .into_iter()
+                .chain(self.tail.datapath_programs().into_iter())
+                .collect()
+        }
+    }
+}
+
+use sealed::*;
+
+/// Main execution loop of CCP for the static pipeline use case.
+/// The `run` method blocks 'forever'; it only returns in two cases:
+/// 1. The IPC socket is closed.
+/// 2. An invalid message is received.
+///
+/// Callers must construct a `BackendBuilder` and a `Config`.
+/// Algorithm implementations should
+/// 1. Initializes an ipc backendbuilder (depending on the datapath).
+/// 2. Calls `run()`, or `spawn() `passing the `BackendBuilder b` and a `Config` with optional
+/// logger and command line argument structure.
+/// Run() or spawn() create arc<AtomicBool> objects,
+/// which are passed into run_inner to build the backend, so spawn() can create a CCPHandle that references this
+/// boolean to kill the thread.
+///
+/// # Example
+///
+/// Configuration:
+/// ```rust,no_run
+/// use std::collections::HashMap;
+/// use portus::{CongAlg, Flow, Config, Datapath, DatapathInfo, DatapathTrait, Report};
+/// use portus::ipc::Ipc;
+/// use portus::lang::Scope;
+/// use portus::lang::Bin;
+///
+/// const PROG: &str = "
+///       (def (Report
+///           (volatile minrtt +infinity)
+///       ))
+///       (when true
+///           (:= Report.minrtt (min Report.minrtt Flow.rtt_sample_us))
+///       )
+///       (when (> Micros 42000)
+///           (report)
+///           (reset)
+///       )";
+///
+///
+/// #[derive(Clone, Default)]
+/// struct AlgOne(Scope);
+///
+/// impl<I: Ipc> CongAlg<I> for AlgOne {
+///     type Flow = Self;
+///
+///     fn name() -> &'static str {
+///         "Default Alg"
+///     }
+///     fn datapath_programs(&self) -> HashMap<&'static str, String> {
+///         let mut h = HashMap::default();
+///         h.insert("MyProgram", PROG.to_owned());
+///         h
+///     }
+///     fn new_flow(&self, mut control: Datapath<I>, info: DatapathInfo) -> Self::Flow {
+///         let sc = control.set_program("MyProgram", None).unwrap();
+///         AlgOne(sc)
+///     }
+/// }
+/// impl Flow for AlgOne {
+///     fn on_report(&mut self, sock_id: u32, m: Report) {
+///         println!("alg1 minrtt: {:?}", m.get_field("Report.minrtt", &self.0).unwrap());
+///     }
+/// }
+///
+/// #[derive(Clone, Default)]
+/// struct AlgTwo(Scope);
+///
+/// impl<I: Ipc> CongAlg<I> for AlgTwo {
+///     type Flow = Self;
+///
+///     fn name() -> &'static str {
+///         "Alg2"
+///     }
+///     fn datapath_programs(&self) -> HashMap<&'static str, String> {
+///         let mut h = HashMap::default();
+///         h.insert("MyProgram", PROG.to_owned());
+///         h
+///     }
+///     fn new_flow(&self, mut control: Datapath<I>, info: DatapathInfo) -> Self::Flow {
+///         let sc = control.set_program("MyProgram", None).unwrap();
+///         AlgTwo(sc)
+///     }
+/// }
+/// impl Flow for AlgTwo {
+///     fn on_report(&mut self, sock_id: u32, m: Report) {
+///         println!("alg2 minrtt: {:?}", m.get_field("Report.minrtt", &self.0).unwrap());
+///     }
+/// }
+///
+/// use portus::RunBuilder;
+/// use portus::ipc::{BackendBuilder, unix::Socket};
+/// let b = Socket::<portus::ipc::Blocking>::new("in", "out").map(|sk| BackendBuilder { sock: sk }).expect("ipc initialization");
+/// let rb = RunBuilder::new(b, Config::default())
+///   .default_alg(AlgOne::default())
+///   .additional_alg(AlgTwo::default());
+///   // .spawn_thread() to spawn runtime in a thread
+///   // .with_stop_handle() to pass in an Arc<AtomicBool> that will stop the runtime
+/// rb.run();
+/// ```
+pub struct RunBuilder<I: Ipc, U, Spawnness> {
+    backend_builder: BackendBuilder<I>,
+    alg: U,
+    cfg: Config,
+    stop_handle: Option<*const atomic::AtomicBool>,
+    _phantom: std::marker::PhantomData<Spawnness>,
+}
+
+pub struct Spawn;
+pub struct NoSpawn;
+
+impl<I: Ipc> RunBuilder<I, (), NoSpawn> {
+    pub fn new(backend_builder: BackendBuilder<I>, cfg: Config) -> Self {
+        Self {
+            backend_builder,
+            cfg,
+            alg: (),
+            stop_handle: None,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<I: Ipc, S> RunBuilder<I, (), S> {
+    /// Set the default congestion control algorithm. This is required to run or spawn anything.
+    ///
+    /// This is the algorithm that will be used if the name the datapath requests doesn't match
+    /// anything.
+    pub fn default_alg<A>(self, alg: A) -> RunBuilder<I, AlgListNil<A>, S> {
+        RunBuilder {
+            alg: AlgListNil(alg),
+            backend_builder: self.backend_builder,
+            cfg: self.cfg,
+            stop_handle: self.stop_handle,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<I: Ipc, U, S> RunBuilder<I, U, S> {
+    /// Set an additional congestion control algorithm.
+    ///
+    /// If the name duplicates one already given, the later one will win.
+    pub fn additional_alg<A: CongAlg<I>>(self, alg: A) -> RunBuilder<I, AlgList<A, U>, S> {
+        RunBuilder {
+            alg: AlgList {
+                head_name: A::name().to_owned(),
+                head: alg,
+                tail: self.alg,
+            },
+            backend_builder: self.backend_builder,
+            cfg: self.cfg,
+            stop_handle: self.stop_handle,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Pass an `AtomicBool` stop handle.
+    pub fn with_stop_handle(self, handle: Arc<atomic::AtomicBool>) -> Self {
+        Self {
+            stop_handle: Some(Arc::into_raw(handle)),
+            ..self
+        }
+    }
+
+    /// Pass a raw pointer to an `AtomicBool` stop handle.
+    ///
+    /// # Safety
+    /// `handle_ptr` must be from
+    /// [`Arc::into_raw()`](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.from_raw).
+    // this is unsafe so that we can safely use unsafe blocks when actually running: we need to
+    // pass the unsafe parcel to the caller, since we can't guarantee safety.
+    pub unsafe fn with_raw_stop_handle(self, handle_ptr: *const atomic::AtomicBool) -> Self {
+        Self {
+            stop_handle: Some(handle_ptr),
+            ..self
+        }
+    }
+
+    fn stop_handle(&self) -> Result<Arc<atomic::AtomicBool>> {
+        if let Some(ptr) = self.stop_handle {
+            if ptr.is_null() {
+                return Err(Error(String::from("handle is null")));
+            }
+
+            Ok(unsafe { Arc::from_raw(ptr) })
+        } else {
+            Ok(Arc::new(atomic::AtomicBool::new(true)))
+        }
+    }
+}
+
+impl<I: Ipc, U> RunBuilder<I, U, NoSpawn> {
+    /// Spawn a thread which will perform the CCP execution loop. Returns
+    /// a `CCPHandle`, which the caller can use to cause the execution loop
+    /// to stop.
+    /// The `run` method blocks 'forever'; it only returns in three cases:
+    /// 1. The IPC socket is closed.
+    /// 2. An invalid message is received.
+    /// 3. The caller calls `CCPHandle::kill()`
+    ///
+    /// See [`run`](./fn.run.html) for more information.
+    pub fn spawn_thread(self) -> RunBuilder<I, U, Spawn> {
+        RunBuilder {
+            backend_builder: self.backend_builder,
+            cfg: self.cfg,
+            stop_handle: self.stop_handle,
+            alg: self.alg,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<I, U> RunBuilder<I, U, NoSpawn>
+where
+    I: Ipc,
+    U: 'static,
+    for<'a> &'a U: Pick<'a, I> + CollectDps<I>,
+{
+    pub fn run(self) -> Result<()> {
+        let h = self.stop_handle()?;
+        run_inner(h, self.backend_builder, self.cfg, self.alg)
+    }
+}
+
+impl<I, U> RunBuilder<I, U, Spawn>
+where
+    I: Ipc,
+    U: Send + 'static,
+    for<'a> &'a U: Pick<'a, I> + CollectDps<I>,
+{
+    pub fn run(self) -> Result<CCPHandle> {
+        let stop_signal = self.stop_handle()?;
+        let bb = self.backend_builder;
+        let cfg = self.cfg;
+        let alg = self.alg;
+        Ok(CCPHandle {
+            continue_listening: stop_signal.clone(),
+            join_handle: thread::spawn(move || run_inner(stop_signal, bb, cfg, alg)),
+        })
+    }
+}
+
+// Main execution inner loop of ccp.
+// Blocks "forever", or until the iterator stops iterating.
+//
+// `run_inner()`:
+// 1. listens for messages from the datapath
+// 2. call the appropriate message in `U: impl CongAlg`
+// The function can return for two reasons: an error, or the iterator returned None.
+// The latter should only happen for spawn(), and not for run().
+// It returns any error, either from:
+// 1. the IPC channel failing
+// 2. Receiving an install control message (only the datapath should receive these).
+fn run_inner<I, U>(
+    continue_listening: Arc<atomic::AtomicBool>,
+    backend_builder: BackendBuilder<I>,
+    cfg: Config,
+    algs: U,
+) -> Result<()>
+where
+    I: Ipc,
+    U: 'static,
+    for<'a> &'a U: Pick<'a, I> + CollectDps<I>,
+{
+    let mut receive_buf = [0u8; 1024];
+    let mut b = backend_builder.build(continue_listening.clone(), &mut receive_buf[..]);
+    // the borrow has to be fore the HashMap, to guarantee that the HashMap is dropped first
+    let algs2 = &algs;
+    let mut flows = HashMap::<u32, <<&'_ U as Pick<'_, I>>::Picked as CongAlg<I>>::Flow>::default();
+    let backend = b.sender();
+
+    if let Some(log) = cfg.logger.as_ref() {
+        info!(log, "starting CCP";
+            "ipc"       => I::name(),
+        );
+    }
+
+    let mut scope_map = Rc::new(HashMap::<String, Scope>::default());
+
+    let programs = algs2.datapath_programs();
+    for (program_name, program) in programs.iter() {
+        match lang::compile(program.as_bytes(), &[]) {
+            Ok((bin, sc)) => {
+                match send_and_install(0, &backend, bin, &sc) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(Error(format!(
+                            "Failed to install datapath program \"{}\": {:?}",
+                            program_name, e
+                        )));
+                    }
+                }
+                Rc::get_mut(&mut scope_map)
+                    .unwrap()
+                    .insert(program_name.to_string(), sc.clone());
+            }
+            Err(e) => {
+                return Err(Error(format!(
+                    "Datapath program \"{}\" failed to compile: {:?}",
+                    program_name, e
+                )));
+            }
+        }
+    }
+
+    while let Some(msg) = b.next() {
+        match msg {
+            Msg::Cr(c) => {
+                if flows.remove(&c.sid).is_some() {
+                    if let Some(log) = cfg.logger.as_ref() {
+                        debug!(log, "re-creating already created flow"; "sid" => c.sid);
+                    }
+                }
+
+                if let Some(log) = cfg.logger.as_ref() {
+                    debug!(log, "creating new flow";
+                           "sid" => c.sid,
+                           "init_cwnd" => c.init_cwnd,
+                           "mss"  =>  c.mss,
+                           "src_ip"  =>  c.src_ip,
+                           "src_port"  =>  c.src_port,
+                           "dst_ip"  =>  c.dst_ip,
+                           "dst_port"  =>  c.dst_port,
+                    );
+                }
+
+                let alg = algs2.pick(c.cong_alg.as_ref().map(String::as_str).unwrap_or(""));
+                let f = alg.new_flow(
+                    Datapath {
+                        sock_id: c.sid,
+                        sender: backend.clone(),
+                        programs: scope_map.clone(),
+                    },
+                    DatapathInfo {
+                        sock_id: c.sid,
+                        init_cwnd: c.init_cwnd,
+                        mss: c.mss,
+                        src_ip: c.src_ip,
+                        src_port: c.src_port,
+                        dst_ip: c.dst_ip,
+                        dst_port: c.dst_port,
+                    },
+                );
+                flows.insert(c.sid, f);
+            }
+            Msg::Ms(m) => {
+                if flows.contains_key(&m.sid) {
+                    if m.num_fields == 0 {
+                        let mut flow = flows.remove(&m.sid).unwrap();
+                        flow.close();
+                    } else {
+                        let flow = flows.get_mut(&m.sid).unwrap();
+                        flow.on_report(
+                            m.sid,
+                            Report {
+                                program_uid: m.program_uid,
+                                fields: m.fields,
+                            },
+                        )
+                    }
+                } else if let Some(log) = cfg.logger.as_ref() {
+                    debug!(log, "measurement for unknown flow"; "sid" => m.sid);
+                }
+            }
+            Msg::Ins(_) => {
+                // The start() listener should never receive an install message, since it is on the CCP side.
+                unreachable!()
+            }
+            _ => continue,
+        }
+    }
+
+    // if the thread has been killed, return that as error
+    if !continue_listening.load(atomic::Ordering::SeqCst) {
+        Ok(())
+    } else {
+        Err(Error(String::from("The IPC channel has closed.")))
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -329,7 +329,8 @@ use sealed::*;
 /// let b = Socket::<portus::ipc::Blocking>::new("in", "out").map(|sk| BackendBuilder { sock: sk }).expect("ipc initialization");
 /// let rb = RunBuilder::new(b, Config::default())
 ///   .default_alg(AlgOne::default())
-///   .additional_alg(AlgTwo::default());
+///   .additional_alg(AlgTwo::default())
+///   .additional_alg::<AlgOne, _>(None);
 ///   // .spawn_thread() to spawn runtime in a thread
 ///   // .with_stop_handle() to pass in an Arc<AtomicBool> that will stop the runtime
 /// rb.run();
@@ -377,9 +378,9 @@ impl<I: Ipc, U, S> RunBuilder<I, U, S> {
     /// Set an additional congestion control algorithm.
     ///
     /// If the name duplicates one already given, the later one will win.
-    pub fn additional_alg<A: CongAlg<I>>(
+    pub fn additional_alg<A: CongAlg<I>, O: Into<Option<A>>>(
         self,
-        alg: impl Into<Option<A>>,
+        alg: O,
     ) -> RunBuilder<I, AlgList<Option<A>, U>, S> {
         RunBuilder {
             alg: AlgList {

--- a/src/serialize/create.rs
+++ b/src/serialize/create.rs
@@ -44,7 +44,7 @@ impl AsRawMsg for Msg {
         let mut buf = [0u8; 64];
         if let Some(c) = &self.cong_alg {
             if c.len() > 63 {
-                return Err(Error(format!("Cong alg name too long")));
+                return Err(Error(String::from("Cong alg name too long")));
             } else {
                 buf.copy_from_slice(c.as_bytes());
             }

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Messages have a common CCP header:
 //!
-//! ```no-run
+//! ```text
 //! -----------------------------------
 //! | Msg Type | Len (B)  | Uint32    |
 //! | (2 B)    | (2 B)    | (32 bits) |
@@ -24,7 +24,6 @@
 //! External message types can implement `get_bytes()` to pass custom types in the message payload.
 //! In these cases, there is little deserialization overhead from the u32 and u64 parts of the message.
 
-use std;
 use std::io::prelude::*;
 use std::io::Cursor;
 use std::vec::Vec;

--- a/src/serialize/testmsg.rs
+++ b/src/serialize/testmsg.rs
@@ -1,6 +1,5 @@
 use super::{AsRawMsg, RawMsg, HDR_LENGTH};
 use crate::Result;
-use std;
 use std::io::prelude::*;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -1,7 +1,5 @@
 //! Helper type for writing unit tests.
 
-use std;
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct TestMsg(pub String);
 
@@ -19,7 +17,7 @@ impl serialize::AsRawMsg for TestMsg {
 
     fn from_raw_msg(msg: serialize::RawMsg) -> super::Result<Self> {
         let b = msg.get_bytes()?;
-        let got: String = std::str::from_utf8(&b[..])
+        let got: String = std::str::from_utf8(b)
             .expect("parse message to str")
             .chars()
             .take_while(|b| *b != '\0')

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,8 @@
+#[cfg_attr(test, macro_use)]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 use std::time::Instant;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 use std::time::Instant;
 

--- a/tests/libccp_integration/mod.rs
+++ b/tests/libccp_integration/mod.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use portus::ipc::Ipc;
 use portus::lang::Scope;
 use portus::{CongAlg, Datapath, DatapathInfo, DatapathTrait, Flow, Report};
-use slog::{o, Drain};
+use slog::Drain;
 use std::collections::HashMap;
 
 pub const ACKED_PRIMITIVE: u32 = 5; // libccp uses this same value for acked_bytes
@@ -140,5 +140,5 @@ pub fn logger() -> slog::Logger {
         .build()
         .filter_level(slog::Level::Debug)
         .fuse();
-    slog::Logger::root(human_drain, o!())
+    slog::Logger::root(human_drain, slog::o!())
 }

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -1,6 +1,8 @@
+#[cfg_attr(test, macro_use)]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;

--- a/tests/timing.rs
+++ b/tests/timing.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 

--- a/tests/timing.rs
+++ b/tests/timing.rs
@@ -1,6 +1,8 @@
+#[cfg_attr(test, macro_use)]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 

--- a/tests/twoflow.rs
+++ b/tests/twoflow.rs
@@ -1,6 +1,8 @@
+#[cfg_attr(test, macro_use)]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 use std::time::Instant;
 

--- a/tests/twoflow.rs
+++ b/tests/twoflow.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 use std::time::Instant;
 

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,6 +1,8 @@
+#[macro_use]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;

--- a/tests/volatile.rs
+++ b/tests/volatile.rs
@@ -1,6 +1,8 @@
+#[cfg_attr(test, macro_use)]
+extern crate slog;
+
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
-use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;

--- a/tests/volatile.rs
+++ b/tests/volatile.rs
@@ -1,15 +1,6 @@
-extern crate fnv;
-extern crate portus;
-#[macro_use]
-extern crate slog;
-extern crate failure;
-extern crate libccp;
-extern crate minion;
-extern crate slog_term;
-extern crate time;
-
 use portus::lang::Scope;
 use portus::{DatapathTrait, Report};
+use slog::info;
 use std::collections::HashMap;
 
 mod libccp_integration;


### PR DESCRIPTION
Add support for "dynamically" picking between multiple algorithms. This takes advantage of the new version of libccp, https://github.com/ccp-project/libccp/commit/076cbd976a0c79a93e2a129d4abde8429b740a7f, which includes the datapath's requested CCA in the create message.

This also subsumes run/spawn and `run_with_handle` from commit `d34218b` with a new builder pattern for getting things running:
```rust
let rb = RunBuilder::new(..., Config::default())
  .default_alg(AlgOne::default())
  .additional_alg(AlgTwo::default());
  // .spawn_thread() to spawn runtime in a thread
  // .with_stop_handle() to pass in an Arc<AtomicBool> that will stop the runtime
rb.run();
```

It uses `CongAlg::name()` as the key to lookup what the datapath sends.

Since this is backwards-incompatible, bump version to 0.6.0.

