### PR TITLE
Add named socket in python

### DIFF
--- a/python/example/const_named.py
+++ b/python/example/const_named.py
@@ -1,0 +1,42 @@
+import sys
+import pyportus as portus
+
+class ConstFlow():
+    INIT_RATE = 1000000
+
+    def __init__(self, datapath, datapath_info):
+        self.datapath = datapath
+        self.datapath_info = datapath_info
+        self.rate = ConstFlow.INIT_RATE
+        self.datapath.set_program("default", [("Rate", self.rate)])
+
+    def on_report(self, r):
+        self.datapath.update_field("Rate", self.rate)
+
+
+class Const(portus.AlgBase):
+
+    def datapath_programs(self):
+        return {
+                "default" : """\
+                (def (Report
+                    (volatile acked 0)
+                    (volatile loss 0)
+                    (volatile rtt 0)
+                ))
+                (when true
+                    (:= Report.rtt Flow.rtt_sample_us)
+                    (:= Report.acked (+ Report.acked Ack.bytes_acked))
+                    (:= Report.loss Ack.lost_pkts_sample)
+                    (report)
+                )
+            """
+        }
+
+    def new_flow(self, datapath, datapath_info):
+        return ConstFlow(datapath, datapath_info)
+
+alg = Const()
+
+# You will find socket in /tmp/ccp/hello in ubuntu
+portus.start("unix", alg, "hello")

--- a/python/pyportus/__init__.py
+++ b/python/pyportus/__init__.py
@@ -31,13 +31,16 @@ class AlgBase(object):
                         ))
             return True
 
-def start(ipc, alg):
+'''
+@identifier: ipc = "unix" only. It will be used to create unix socket to allow multi CCP run together without interference with each other, default is "portus"
+'''
+def start(ipc, alg, identifier="portus"):
     cls = alg.__class__
     if not issubclass(cls, object):
         raise Exception(cls.__name__ + " must be a subclass of object")
     if issubclass(cls, AlgBase):
         AlgBase.assert_implements_interface(cls)
         checker._check_datapath_programs(cls)
-        return start_inner(ipc, alg)
+        return start_inner(ipc, alg, identifier)
     else:
         raise Exception(cls.__name__ + " must be a subclass of portus.AlgBase")

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -58,6 +58,6 @@ impl IntegrationTest for TestBasicSerialize {
 
 #[test]
 fn basic() {
-    info!("starting basic test 233");
+    info!("starting basic test");
     libccp_integration::run_test::<TestBasicSerialize>(1);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -58,6 +58,6 @@ impl IntegrationTest for TestBasicSerialize {
 
 #[test]
 fn basic() {
-    info!("starting basic test");
+    info!("starting basic test 233");
     libccp_integration::run_test::<TestBasicSerialize>(1);
 }


### PR DESCRIPTION
I want to use multi CCP program in parallel if they all use "portus" as their unix socket there might cause some issue. I expose the name parameter as the function `start` 's parameter